### PR TITLE
Disable Livereload -> no more EM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'http://rubygems.org'
 gem "middleman", "~>3.3.5"
 
 # Live-reloading plugin
-gem "middleman-livereload", "~> 3.1.0"
+# gem "middleman-livereload", "~> 3.1.0"
 
 # For faster file watcher updates on Windows:
 gem "wdm", "~> 0.1.0", :platforms => [:mswin, :mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,11 +26,7 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    em-websocket (0.5.1)
-      eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    eventmachine (1.0.3)
     execjs (2.2.1)
     ffi (1.9.3)
     haml (4.0.5)
@@ -38,7 +34,6 @@ GEM
     hike (1.2.3)
     hooks (0.4.0)
       uber (~> 0.0.4)
-    http_parser.rb (0.6.0)
     i18n (0.6.11)
     json (1.8.1)
     kramdown (1.4.1)
@@ -73,11 +68,6 @@ GEM
       middleman-core (>= 3.2)
       net-sftp
       ptools
-    middleman-livereload (3.1.1)
-      em-websocket (>= 0.2.0)
-      middleman-core (>= 3.0.2)
-      multi_json (~> 1.0)
-      rack-livereload
     middleman-sprockets (3.3.7)
       middleman-core (~> 3.3)
       sprockets (~> 2.12.1)
@@ -96,8 +86,6 @@ GEM
       activesupport (>= 3.1)
     ptools (1.2.6)
     rack (1.5.2)
-    rack-livereload (0.3.15)
-      rack
     rack-test (0.6.2)
       rack (>= 1.0)
     rb-fsevent (0.9.4)
@@ -131,6 +119,5 @@ PLATFORMS
 DEPENDENCIES
   middleman (~> 3.3.5)
   middleman-deploy (~> 0.3.0)
-  middleman-livereload (~> 3.1.0)
   tzinfo-data
   wdm (~> 0.1.0)

--- a/config.rb
+++ b/config.rb
@@ -37,7 +37,7 @@
 
 # Reload the browser automatically whenever files change
 configure :development do
-  activate :livereload
+  # activate :livereload
 end
 
 # Methods defined in the helpers block are available in templates


### PR DESCRIPTION
Livereload is nice but depends on EventMachine, which has spotty forward and backwards compatibility.
