### PR TITLE
Various changes of margins and paddings

### DIFF
--- a/source/css/main.css.erb
+++ b/source/css/main.css.erb
@@ -1,26 +1,8 @@
-// Syntax highlighting
+/* Syntax highlighting */
 <%= Rouge::Themes::Github.render(:scope => '.highlight') %>
 
 body {
   font-size: 16px;
-}
-
-.screenshot {
-  padding: 10px;
-}
-
-.screenshot img {
-  border: thin solid gray;
-}
-
-.site-footer {
-  margin-top: 50px;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  font-size: 13px;
-  color: #777;
-  border-top: 1px solid #e5e5e5;
-  text-align: center;
 }
 
 /* Override link color */
@@ -37,4 +19,38 @@ a:focus {
 .nav-pills > li.active > a:hover,
 .nav-pills > li.active > a:focus {
   background-color: #7e4bad;
+}
+
+/* Logo */
+.sidebar-logo {
+  padding: 25px 0 18px 15px;
+}
+
+.big-logo {
+  text-align: center;
+  padding: 0 20px 30px 0;
+}
+
+/* Screenshot */
+.screenshot {
+  padding: 10px 0;
+}
+
+.screenshot img {
+  border: thin solid gray;
+}
+
+/* Footer */
+.site-footer {
+  margin-top: 50px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  font-size: 13px;
+  color: #777;
+  border-top: 1px solid #e5e5e5;
+  text-align: center;
+}
+
+.site-footer-link-list {
+  margin-left: 0;
 }

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -2,7 +2,9 @@
 title: 
 ---
 
-<%= image_tag 'octo_logo2.png', :width => '350px' %>
+<div class="big-logo">
+  <%= image_tag 'octo_logo2.png', :width => '250px' %>
+</div>
 
 <h3>What's this?</h3>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -28,10 +28,12 @@
       <div class="row">
 
         <div class="col-md-3">
-          <div id="sidebar" style="padding-top: 20px;">
-            <% link_to '/index.html' do %>
-                <%= image_tag 'octo_logo1.png', :width => '220px', :style => 'padding-left: 15px;' %>
-            <% end %>
+          <div id="sidebar">
+            <div class="sidebar-logo">
+              <% link_to '/index.html' do %>
+                  <%= image_tag 'octo_logo1.png', :width => '220px' %>
+              <% end %>
+            </div>
 
             <ul class="nav nav-pills nav-stacked">
             <% sitemap.where(:nav_order.gte => 0).order_by(:nav_order).all.each { |page| %>
@@ -58,7 +60,7 @@
         </div>
         <div class="row">
           <div class="col-md-12">
-            <ul class="list-inline">
+            <ul class="list-inline site-footer-link-list">
                 <li>
                   <%= link_to "M3Dev", "http://m3dev.github.io/"  %>
                 </li>


### PR DESCRIPTION
- Center the large logo.
- Add more space below the site logo so that it won't touch the Getting Started menu item on Getting Started page.

![screen shot 2014-09-05 at 12 05 01 am](https://cloud.githubusercontent.com/assets/498635/4151410/d39ffa3c-3445-11e4-8846-3b162b201287.png)
- Exactly center the footer links.

![screen shot 2014-09-05 at 12 05 18 am](https://cloud.githubusercontent.com/assets/498635/4151411/d5c809bc-3445-11e4-9d09-f053db960b5c.png)
- Align left edges of screenshots with texts.
- Fix invalid comment syntax in CSS.
- Move inline styles to external CSS file.
