### PR TITLE
Changing "no-cache" to "no-store" in Cache-Controll header

### DIFF
--- a/source/caching.md.erb
+++ b/source/caching.md.erb
@@ -59,7 +59,7 @@ If the client sets this header when performing an aggregate request, Octoparts w
 
 #### Backend APIs
 
-* `Cache-Control: no-cache`
+* `Cache-Control: no-store`
 
 If this header is set on an API response, Octoparts will guarantee not to insert the response into the cache. Note, however, that if the response already happens to be present in the cache, Octoparts will not remove it.
 


### PR DESCRIPTION
The Cache-Control directive by which backend API tells Octoparts not to store the response into cache, is changed from "no-cache" to "no-store" according to the HTTP 1/1 spec.

If the pull request: https://github.com/m3dev/octoparts/pull/6 is merged, please merge this.
