### PR TITLE
Getting Started What's Next Section and Next Links

### DIFF
--- a/source/alert-mails.md.erb
+++ b/source/alert-mails.md.erb
@@ -8,3 +8,5 @@ You may have noticed that there is an "Alert Mail" configuration section when yo
 We have plans to open-source our Alert Mailer, which takes advantage of this data to send you e-mails when errors on your registered endpoints have crossed your configured thresholds.
 
 Keep an eye on this page for further updates and details on this feature.
+
+**Next**: Learn how you can <%= link_to "contribute to Octoparts", "/contributing.html" %>

--- a/source/caching.md.erb
+++ b/source/caching.md.erb
@@ -211,3 +211,5 @@ This flowchart shows the gory details of how Octoparts looks up an API response 
     <%= image_tag "cache-lookup-sequence.png", :width => '500px' %>
   <% end %>
 </div>
+
+**Next**: Read about <%= link_to "Timeouts", "/timeouts.html" %>

--- a/source/getting-started.md.erb
+++ b/source/getting-started.md.erb
@@ -185,4 +185,4 @@ If you used Vagrant to install, you can instantly check out various services rel
 * Kibana - <%= link_to "Sample Dashboard", "http://localhost:5080/kibana-3.0.1/index.html#/dashboard/file/guided.json", :target => "_blank" %>
 * Hystrix - <%= link_to "Sample Dashboard", "http://localhost:8080/dashboard/monitor/monitor.html?stream=http%3A%2F%2Flocalhost%3A9000%2Fhystrix.stream", :target => "_blank" %>
 
-Next: Read about <%= link_to "Octoparts' HTTP API", "/http-api.html" %>
+**Next**: Read about <%= link_to "Octoparts' HTTP API", "/http-api.html" %>

--- a/source/getting-started.md.erb
+++ b/source/getting-started.md.erb
@@ -177,3 +177,12 @@ If all went well, you should see a JSON response that looks something like this:
 ```
 
 Congratulations, you've successfully created and tested your first endpoint!
+
+## What's next?
+
+If you used Vagrant to install, you can instantly check out various services related to the endpoint you just made.
+
+* Kibana - <%= link_to "Sample Dashboard", "http://localhost:5080/kibana-3.0.1/index.html#/dashboard/file/guided.json", :target => "_blank" %>
+* Hystrix - <%= link_to "Sample Dashboard", "http://localhost:8080/dashboard/monitor/monitor.html?stream=http%3A%2F%2Flocalhost%3A9000%2Fhystrix.stream", :target => "_blank" %>
+
+Next: Read about <%= link_to "Octoparts' HTTP API", "/http-api.html" %>

--- a/source/http-api.md.erb
+++ b/source/http-api.md.erb
@@ -168,3 +168,5 @@ libraryDependencies ++= Seq(
 ```
 
 Just like the Java client, we cross-publish for Scala 2.10 and 2.11.
+
+**Next**: Read about <%= link_to "Caching", "/caching.html" %>

--- a/source/internals.md.erb
+++ b/source/internals.md.erb
@@ -37,3 +37,5 @@ When a POST request is sent to the [endpoints invocation API](http://localhost:9
 3. All the `PartResponse`s are gathered into a single `AggregateResponse` object. *Note:* `PartRequest`s that take longer than the default or requested timeout duration to process are mapped to a `PartResponse` with a timeout error (for more details, see [Timeouts](../timeouts.html))
 4. The `AggregateResponse` is serialised into a JSON object
 5. The JSON object is sent as a string in the body of the HTTP response
+
+**Next**: Read about <%= link_to "Runtime Info", "/runtime-info.html" %>

--- a/source/logging-visualization.md.erb
+++ b/source/logging-visualization.md.erb
@@ -133,3 +133,5 @@ Spans logged to Zipkin will include:
 - HTTP request wait times
 
 Octoparts will also play nice with the rest of your Zipkin-enabled infrastructure, meaning it will properly respect Zipkin ids sent to it in HTTP headers (it will set the parent-id of it's Server Spans to be the client span id sent to it and maintain the same trace-id) and it will forward Zipkin headers to any HTTP endpoints it calls. This ensures that you can have 1 big trace from beginning to end, allowing you to pinpoint/track bottlenecks in your distributed systems.
+
+**Next**: Read about <%= link_to "Octoparts' Internals", "/internals.html" %>

--- a/source/runtime-info.md.erb
+++ b/source/runtime-info.md.erb
@@ -137,3 +137,5 @@ Example response:
 ```
 
 As the path implies, this endpoint provides build-time information, in JSON form.
+
+**Next**: Read about <%= link_to "Alert Mails", "/alert-mails.html" %>

--- a/source/timeouts.md.erb
+++ b/source/timeouts.md.erb
@@ -35,3 +35,5 @@ Those familiar with Scala may want to checkout our `RichFutureWithTimeout` enric
 ## Motivation for having 2 types of timeouts
 
 Asides from the two types serving 2 different functional requirements, the separation our timeouts allow us to do something cool: even if a request timeout has occured for a given `PartRequest`, so long as the corresponding `HystrixCommand` hasn't timed out, we can cache the eventual result of the `HystrixCommand` so that the next time the same `PartRequest` is processed by Octoparts, we have a chance of getting a cache hit, which allows us to respond immediately. For more details, see [Caching](../caching.html)
+
+**Next**: Read about <%= link_to "Logging & Visualization", "/logging-visualization.html" %>


### PR DESCRIPTION
At the end of getting started, there's no advice on how to check out Kibana or Hystrix right away. Added links to the services as they run on the virtual machine for Vagrant users.

Also added "next" links to the bottom of pages, to keep the flow of the guide going and keep people engaged.

Please let me know if this makes sense. Thanks.
